### PR TITLE
Fix deprecated usage of pandas

### DIFF
--- a/yahoo_historical/fetch.py
+++ b/yahoo_historical/fetch.py
@@ -74,8 +74,8 @@ class Fetcher:
 
     def getDatePrice(self):
         """Returns a DataFrame for Date and Price from getHistorical()"""
-        return self.getHistorical().ix[:, [0, 4]]
+        return self.getHistorical().iloc[:,[0,4]]
 
     def getDateVolume(self):
         """Returns a DataFrame for Date and Volume from getHistorical()"""
-        return self.getHistorical().ix[:, [0, 6]]
+        return self.getHistorical().iloc[:,[0,6]]


### PR DESCRIPTION
Closes #15: FutureWarning: .ix is deprecated
https://github.com/AndrewRPorter/yahoo-historical/issues/15

https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#ix-indexer-is-deprecated