### PR TITLE
Fixed 403 forbidden error

### DIFF
--- a/yahoo_historical/fetch.py
+++ b/yahoo_historical/fetch.py
@@ -32,7 +32,7 @@ class Fetcher:
 
         url = self.api_url % (self.ticker, self.start, self.end, self.interval, events)
 
-        data = requests.get(url, cookies={"User-agent": "Mozilla/5.0"})
+        data = requests.get(url, headers={"User-agent": "Mozilla/5.0"})
         content = StringIO(data.content.decode("utf-8"))
         return pd.read_csv(content, sep=",")
 


### PR DESCRIPTION
User agent is expected to set in request headers, otherwise Yahoo will reject the request and return 403 error