### PR TITLE
Old API URL doesn't work anymore. Here is a workaround.

### DIFF
--- a/yahoo_historical/constants.py
+++ b/yahoo_historical/constants.py
@@ -1,4 +1,5 @@
-API_URL = "https://query1.finance.yahoo.com/v7/finance/download/%s?period1=%s&period2=%s&interval=%s&events=%s"
+# OLD::  API_URL = "https://query1.finance.yahoo.com/v7/finance/download/%s?period1=%s&period2=%s&interval=%s&events=%s"
+API_URL = "https://query2.finance.yahoo.com/v8/finance/chart/%s?period1=%s&period2=%s&interval=%s&events=%s"
 ONE_DAY_INTERVAL = "1d"
 ONE_WEEK_INTERVAL = "1wk"
 ONE_MONTH_INTERVAL = "1mo"

--- a/yahoo_historical/fetch.py
+++ b/yahoo_historical/fetch.py
@@ -13,12 +13,14 @@ def conv_df(resp):
     # Extract the data explicitly by field name
     timestamps = j['chart']['result'][0]['timestamp']
     indicators = j['chart']['result'][0]['indicators']['quote'][0]
+    adj = j['chart']['result'][0]['indicators']['adjclose'][0]
     
     # Explicitly extract each field by its key to avoid any mismatch
     close = indicators.get('close', [])
     open_ = indicators.get('open', [])
     high = indicators.get('high', [])
     low = indicators.get('low', [])
+    adjclose = adj.get('adjclose', [])
     volume = indicators.get('volume', [])
 
     # Create the DataFrame with the correct order of columns
@@ -28,6 +30,7 @@ def conv_df(resp):
         'High': high,
         'Low': low,
         'Close': close,
+        'Adj Close': adjclose,
         'Volume': volume
     })
     


### PR DESCRIPTION
The old API URL does not work anymore (https://query1.finance.yahoo.com/v7/finance/download/%s?period1=%s&period2=%s&interval=%s&events=%s)

However, this URL works : https://query2.finance.yahoo.com/v8/finance/chart/%s?period1=%s&period2=%s&interval=%s&events=%s

The difference is that the new URL returns the data in JSON format. I made sure that fetch.py can interpret the response, so yahoo-historical can work just as fine as before.


blahem.